### PR TITLE
Patched build bugs until we can find where the codegen went wrong

### DIFF
--- a/src/Com.RusticiSoftware.Cloud.V2/Model/RegistrationCompletion.cs
+++ b/src/Com.RusticiSoftware.Cloud.V2/Model/RegistrationCompletion.cs
@@ -27,27 +27,27 @@ namespace Com.RusticiSoftware.Cloud.V2.Model
     /// <summary>
     /// Defines RegistrationCompletion
     /// </summary>
-    
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum RegistrationCompletion
     {
-        
+
         /// <summary>
         /// Enum UNKNOWN for value: UNKNOWN
         /// </summary>
-        
-        UNKNOWN = UNKNOWN,
-        
+        [EnumMember(Value = "UNKNOWN")]
+        UNKNOWN = 1,
+
         /// <summary>
         /// Enum COMPLETED for value: COMPLETED
         /// </summary>
-        
-        COMPLETED = COMPLETED,
-        
+        [EnumMember(Value = "COMPLETED")]
+        COMPLETED = 2,
+
         /// <summary>
         /// Enum INCOMPLETE for value: INCOMPLETE
         /// </summary>
-        
-        INCOMPLETE = INCOMPLETE
+        [EnumMember(Value = "INCOMPLETE")]
+        INCOMPLETE = 3
     }
 
 }

--- a/src/Com.RusticiSoftware.Cloud.V2/Properties/AssemblyInfo.cs
+++ b/src/Com.RusticiSoftware.Cloud.V2/Properties/AssemblyInfo.cs
@@ -28,5 +28,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0-beta")]
-[assembly: AssemblyFileVersion("1.0.0-beta")]
+//
+// Specifying 1.0.0.0 for now, even though more accurate version would be
+// 1.0.0-beta. However that value breaks the build.
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Surprisingly, this is the only enum for which swagger-codegen generates the code like this, so there has to be some reason it's treated differently than all of the other ones.