### PR TITLE
Upgrade Restsharp version

### DIFF
--- a/src/Com.RusticiSoftware.Cloud.V2/Client/ApiClient.cs
+++ b/src/Com.RusticiSoftware.Cloud.V2/Client/ApiClient.cs
@@ -70,7 +70,7 @@ namespace Com.RusticiSoftware.Cloud.V2.Client
             var options = new RestClientOptions(Configuration.BasePath)
             {
                 UserAgent = Configuration.UserAgent,
-                Timeout = Configuration.Timeout
+                MaxTimeout = Configuration.Timeout
             };
             RestClient = new RestClient(options);
         }

--- a/src/Com.RusticiSoftware.Cloud.V2/Com.RusticiSoftware.Cloud.V2.csproj
+++ b/src/Com.RusticiSoftware.Cloud.V2/Com.RusticiSoftware.Cloud.V2.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="108.0.2" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="JsonSubTypes" Version="1.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>


### PR DESCRIPTION
When we are using the RestSharp 110.2.0, we are getting error on update the ApiClient. because the Timeout was deprecated and replaced by MaxTimeout option.